### PR TITLE
Update marked due to CVE-2017-1000427

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,10 +2,12 @@ language: node_js
 node_js:
   - "0.12"
   - 4    # latest 4.x release
-  - 5    # latest 5.x release
   - 6    # latest 6.x release
-  - 7    # latest 7.x release
+  - 8    # latest 8.x release
   - node # latest stable Node.js release
+matrix:
+  allow_failures:
+    - node_js: node
 sudo: false
 notifications:
   email: false

--- a/package-lock.json
+++ b/package-lock.json
@@ -548,7 +548,7 @@
         "escape-string-regexp": "1.0.5",
         "js2xmlparser": "3.0.0",
         "klaw": "2.0.0",
-        "marked": "0.3.6",
+        "marked": "0.3.12",
         "mkdirp": "0.5.1",
         "requizzle": "0.2.1",
         "strip-json-comments": "2.0.1",
@@ -688,9 +688,9 @@
       }
     },
     "marked": {
-      "version": "0.3.6",
-      "resolved": "https://registry.npmjs.org/marked/-/marked-0.3.6.tgz",
-      "integrity": "sha1-ssbGGPzOzk74bE/Gy4p8v1rtqNc=",
+      "version": "0.3.12",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-0.3.12.tgz",
+      "integrity": "sha512-k4NaW+vS7ytQn6MgJn3fYpQt20/mOgYM5Ft9BYMfQJDz2QT6yEeS9XJ8k2Nw8JTeWK/znPPW2n3UJGzyYEiMoA==",
       "dev": true
     },
     "minimatch": {

--- a/package.json
+++ b/package.json
@@ -17,7 +17,8 @@
     "jsdoc": "^3.4.0",
     "mocha": "^2.4.5",
     "nock-vcr": "0.0.0",
-    "rocha": "^2.0.0"
+    "rocha": "^2.0.0",
+    "marked": "~> 0.3.9"
   },
   "scripts": {
     "preversion": "npm test",


### PR DESCRIPTION
https://nvd.nist.gov/vuln/detail/CVE-2017-1000427

Marked is a dependency of jsdoc. Added marked as a dev dependency to be able to update it to latest version. This is just a temporary fix until https://github.com/jsdoc3/jsdoc/issues/1489 has been released.

Idea from https://github.com/jsdoc3/jsdoc/issues/1489#issuecomment-355521471

Related to #22