### PR TITLE
Link to our new API documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![GitHub Build Status](https://github.com/twingly/twingly-search-api-node/workflows/CI/badge.svg?branch=master)](https://github.com/twingly/twingly-search-api-node/actions)
 
-A Node.js library for Twingly's Search API (previously known as Analytics API). Twingly is a blog search service that provides a searchable API known as [Twingly Search API](https://developer.twingly.com/resources/search/).
+A Node.js library for Twingly's Search API (previously known as Analytics API). Twingly is a blog search service that provides a searchable API known as [Twingly Search API][Twingly Search API documentation].
 
 ## Installation
 
@@ -45,7 +45,9 @@ Find the generated documentation in `out/index.html`.
 
 Example code can be found in [examples/](examples/).
 
-To learn more about the capabilities of the API, please read the [Twingly Search API documentation](https://developer.twingly.com/resources/search/).
+To learn more about the capabilities of the API, please read the [Twingly Search API documentation].
+
+[Twingly Search API documentation]: https://app.twingly.com/blog_search?tab=documentation
 
 ## Requirements
 

--- a/lib/post.js
+++ b/lib/post.js
@@ -19,8 +19,8 @@
  * @property {string} blogId - the blog ID (Twingly internal identification)
  * @property {string} blogName - the name of the blog
  * @property {string} blogUrl - the blog URL
- * @property {number} blogRank - the rank of the blog, based on authority and language. {@link https://developer.twingly.com/resources/ranking/#blogrank}
- * @property {number} authority - the blog's authority/influence. {@link https://developer.twingly.com/resources/ranking/#authority}
+ * @property {number} blogRank - the rank of the blog, based on authority and language. {@link https://app.twingly.com/blog_search?tab=documentation}
+ * @property {number} authority - the blog's authority/influence. {@link https://app.twingly.com/blog_search?tab=documentation}
  *
  * @constructor
  */


### PR DESCRIPTION
As the old site, developer.twingly.com, has been shut down. The documentation for all of our APIs are now available (behind login) at https://app.twingly.com instead.

I didn't link to the specific documentation sections in the code, just so we don't need to update the links in case we restructure the documentation in the future.