### PR TITLE
Update CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,15 +15,15 @@ jobs:
 
     steps:
     - name: Checkout code
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
 
     - name: Setup Node.js ${{ matrix.node }}
-      uses: actions/setup-node@v1
+      uses: actions/setup-node@v3
       with:
         node-version: ${{ matrix.node }}
 
     - name: Cache Node.js modules
-      uses: actions/cache@v2
+      uses: actions/cache@v3
       with:
         path: ~/.npm
         key: ${{ runner.OS }}-node-${{ hashFiles('package-lock.json') }}

--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ To learn more about the capabilities of the API, please read the [Twingly Search
 ## Requirements
 
 * API key, [sign up](https://www.twingly.com/try-for-free) via [twingly.com](https://www.twingly.com/) to get one
-* Node.js (any version listed in [`.travis.yml`](.travis.yml))
+* Node.js (any version listed in [`ci.yml`](.github/workflows/ci.yml))
 
 ## Development
 


### PR DESCRIPTION
https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/

Updated `actions/checkout` major version.
Updated `actions/cache` major version.
Updated `actions/setup-node` major version.

Changelog `setup-node`: https://github.com/actions/setup-node/releases